### PR TITLE
Add M1 support

### DIFF
--- a/.github/workflows/headfull-chromium.yaml
+++ b/.github/workflows/headfull-chromium.yaml
@@ -1,14 +1,16 @@
 name: Publish headfull-chromium
 
-on:
-  push:
-    branches:
-      - main
+#on:
+#  push:
+#    branches:
+#      - main
+on: [push]
 
 env:
   PLAYWRIGHT_VERSION: "1.25.1"
   BUILD_PATH: headfull-chromium
   IMAGE: piercefreeman/headfull-chromium
+  ARCHITECTURES: linux/arm64,linux/amd64
 
 jobs:
   push_to_registry:
@@ -26,7 +28,7 @@ jobs:
 
       - name: Build container
         run: |
-          docker build --tag "$IMAGE:${GITHUB_SHA::7}" --build-arg PLAYWRIGHT_VERSION="$PLAYWRIGHT_VERSION" $BUILD_PATH
+          docker buildx build --tag "$IMAGE:${GITHUB_SHA::7}" --build-arg PLAYWRIGHT_VERSION="$PLAYWRIGHT_VERSION" -o type=image --platform="$ARCHITECTURES" $BUILD_PATH
           docker tag "$IMAGE:${GITHUB_SHA::7}" "$IMAGE:$PLAYWRIGHT_VERSION"
 
       - name: Publish to DockerHub

--- a/.github/workflows/headfull-chromium.yaml
+++ b/.github/workflows/headfull-chromium.yaml
@@ -26,6 +26,16 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
+      # Unlike on OSX with Docker Desktop, a builder is not setup by default. We need this
+      # for downstream buildx tasks.
+      # We first need to setup binfmt to support arm64 builds
+      - name: Setup buildx builder
+        run: |
+          docker run --rm --privileged linuxkit/binfmt@a17941b47f5cb262638cfb49ffc59ac5ac2bf334-amd64
+          docker buildx create --name cibuilder
+          docker buildx use cibuilder
+          docker buildx inspect --bootstrap
+
       - name: Build container
         run: |
           docker buildx build --tag "$IMAGE:${GITHUB_SHA::7}" --build-arg PLAYWRIGHT_VERSION="$PLAYWRIGHT_VERSION" -o type=image --platform="$ARCHITECTURES" $BUILD_PATH

--- a/.github/workflows/headfull-chromium.yaml
+++ b/.github/workflows/headfull-chromium.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Log in to DockerHub
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -29,18 +29,18 @@ jobs:
       # Unlike on OSX with Docker Desktop, a builder is not setup by default. We need this
       # for downstream buildx tasks.
       # We first need to setup binfmt to support arm64 builds
-      - name: Setup buildx builder
-        run: |
-          docker run --rm --privileged linuxkit/binfmt@a17941b47f5cb262638cfb49ffc59ac5ac2bf334-amd64
-          docker buildx create --name cibuilder
-          docker buildx use cibuilder
-          docker buildx inspect --bootstrap
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
 
-      - name: Build container
-        run: |
-          docker buildx build --tag "$IMAGE:${GITHUB_SHA::7}" --build-arg PLAYWRIGHT_VERSION="$PLAYWRIGHT_VERSION" -o type=image --platform="$ARCHITECTURES" $BUILD_PATH
-          docker tag "$IMAGE:${GITHUB_SHA::7}" "$IMAGE:$PLAYWRIGHT_VERSION"
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
 
-      - name: Publish to DockerHub
-        run: |-
-          docker push "$IMAGE:$PLAYWRIGHT_VERSION"
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ${{ env.BUILD_PATH }}
+          platforms: ${{ env.ARCHITECTURES }}
+          push: true
+          tags: ${{ env.IMAGE }}:${{ env.PLAYWRIGHT_VERSION }}


### PR DESCRIPTION
Add arm64 support to the playwright build, which is used during local Mac development. Chrome in particular can't run under amd64 emulation in our docker images because the M1 emulation stack doesn't support some of the underlying kernel functions.