### PR TITLE
Extend cuda support for onnx images

### DIFF
--- a/.github/workflows/cuda-python3.yaml
+++ b/.github/workflows/cuda-python3.yaml
@@ -1,9 +1,9 @@
 name: Publish python-3
 
 on:
-  push:
-    branches:
-      - main
+ push:
+   branches:
+     - main
 
 env:
   BUILD_PATH: cuda-python3
@@ -37,6 +37,9 @@ jobs:
           - python: "3.10.7"
             python_short: "3.10"
             cuda: "11.4.0-base-ubuntu20.04"
+          - python: "3.10.7"
+            python_short: "3.10"
+            cuda: "11.7.1-cudnn8-runtime-ubuntu22.04"
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/cuda-python3/Dockerfile
+++ b/cuda-python3/Dockerfile
@@ -10,7 +10,6 @@ ARG PYTHON_VERSION_SHORT
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential \
     checkinstall \
-    libreadline-gplv2-dev \
     libncursesw5-dev \
     libssl-dev \
     libsqlite3-dev \


### PR DESCRIPTION
The default cuda base image doesn't support running onnx executables. The microsoft [provided](https://github.com/microsoft/onnxruntime/blob/main/dockerfiles/Dockerfile.cuda) image instead prefers to use the runtime executable - which I've confirmed works with the latest version of onnx.