### PR TITLE
Allow node version argument to docker

### DIFF
--- a/.github/workflows/headfull-chromium.yaml
+++ b/.github/workflows/headfull-chromium.yaml
@@ -59,6 +59,6 @@ jobs:
           platforms: ${{ env.ARCHITECTURES }}
           push: true
           tags: ${{ env.IMAGE }}:${{ matrix.playwright_version }}
-          build-args:
-            - PLAYWRIGHT_VERSION=${{ matrix.playwright_version }}
-            - NODE_MAJOR_VERSION=18
+          build-args: |
+            PLAYWRIGHT_VERSION=${{ matrix.playwright_version }}
+            NODE_MAJOR_VERSION=18

--- a/.github/workflows/headfull-chromium.yaml
+++ b/.github/workflows/headfull-chromium.yaml
@@ -1,9 +1,7 @@
 name: Publish headfull-chromium
 
 on:
-  push:
-    branches:
-      - main
+  push
 
 env:
   BUILD_PATH: headfull-chromium
@@ -61,3 +59,6 @@ jobs:
           platforms: ${{ env.ARCHITECTURES }}
           push: true
           tags: ${{ env.IMAGE }}:${{ matrix.playwright_version }}
+          build-args:
+            - PLAYWRIGHT_VERSION=${{ matrix.playwright_version }}
+            - NODE_MAJOR_VERSION=18

--- a/headfull-chromium/Dockerfile
+++ b/headfull-chromium/Dockerfile
@@ -4,13 +4,14 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG TZ=America/Los_Angeles
 
 ARG PLAYWRIGHT_VERSION
+ARG NODE_MAJOR_VERSION
 
 # === INSTALL Node.js ===
 
 RUN apt-get update && \
-    # Install node16
+    # Install node18
     apt-get install -y curl wget gpg && \
-    curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
+    curl -sL https://deb.nodesource.com/setup_$NODE_MAJOR_VERSION.x | bash - && \
     apt-get install -y nodejs && \
     # Feature-parity with node.js base images.
     apt-get install -y --no-install-recommends git openssh-client && \


### PR DESCRIPTION
The node version was previously fixed at 16.x, this PR adds the node major version as a configuration parameter to the dockerfile and github action template so it's easier to upgrade dynamically in the future.

For now we avoid adding multiple concurrent node builds but this should be easy enough to introduce as multiple build matrix arguments.